### PR TITLE
SCHOOLPF-5197 Fix formula picking. Add more tests. Default to 5 stars…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (!project.hasProperty("buildVersion")) {
     ext.buildVersion = "LOCAL-Snapshot"
 }
 group 'com.akelius.university'
-version '1.0.' + buildVersion
+version '1.1.' + buildVersion
 
 
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,1 @@
 rootProject.name = 'university-statistic-core-library'
-
-
-enableFeaturePreview('GRADLE_METADATA')

--- a/src/commonMain/kotlin/com/akelius/university/statistic/core/ScoreCalculator.kt
+++ b/src/commonMain/kotlin/com/akelius/university/statistic/core/ScoreCalculator.kt
@@ -10,12 +10,11 @@ import kotlin.math.abs
 /**
  * Score calculation rules as per SCHOOLPF-4086:
  *
- * 1) Presentation where all slides that have score:0, weight:0 should count automatically as full(5) points.
+ * 1) Presentation where all slides that have weight:0 should count automatically as full(5) points.
  *
  * 2) Then we have mistake based formula, for every mistake made, one point is deduced from maximum(5)
  *
  *      This applies to slideshows with:
- *          - 1 interaction
  *          - 5 interactions
  *          - 10 interactions
  *
@@ -30,75 +29,65 @@ import kotlin.math.abs
  *
  *  Interactions will be recognized if they have weight>0 and score>0.
  *
+ *  4) In slideshow with one slide score is implemented in Interaction itself.
+ *  It defaults because of it to default formula
+ *
  */
 class ScoreCalculator {
 
     companion object {
         const val calculationPrecision = 0.00000001
-        val gradeCalculator = GradeCalculator()
+        internal val gradeCalculator = GradeCalculator()
     }
 
     fun calculate(score: SlideshowScore): SlideshowScoreResult {
         val calculation = Calculation()
 
-        if (score.slideScores.isNotEmpty() && score.slideScores.find { it.weight > 0 } == null) {
-            // if there is not a single weight bigger than zero, this is presentation where we give always 5 points
-            return SlideshowScoreResult(
-                score = 5,
-                scaledScore = 1.0,
-                correctAnswersCount = score.slideScores.size,
-                totalAnswersCount = score.slideScores.size
-            )
-        }
-
         score.slideScores.asSequence().forEach {
             calculation.addSlideScore(it)
         }
+
+        val countInteractions = score.slideScores.count { it.weight > 0 }
+        val calculationType = calculationFormula(score, countInteractions)
+
         val scaledScore = calculateScaledScore(calculation.userScore, calculation.maxScore)
 
-        when (score.slideScores.count { it.weight > 0 }) {
-            1 -> {
-                val scoreInFifths = gradeCalculator.scoreToFifths(score.type, scaledScore)
-                val interaction = score.slideScores.find { it.weight > 0 }
-                return SlideshowScoreResult(
-                    score = scoreInFifths,
-                    scaledScore = scaledScore,
-                    correctAnswersCount = if(interaction!!.isCorrect) 1 else 0,
-                    totalAnswersCount = 1
-                )
+        val scoreInFifths = gradeCalculator.scoreToFifths(
+            calculationType, if (calculationType == CalculationType.MISTAKE) {
+                calculateMistakes(score).toDouble()
+            } else {
+                scaledScore
             }
-            in 2..19 -> {
-                val mistakes = calculateMistakes(score)
+        )
+        return SlideshowScoreResult(
+            score = scoreInFifths,
+            scaledScore = scaledScore,
+            correctAnswersCount = calculation.correctAnswersCount,
+            totalAnswersCount = calculation.totalAnswers
+        )
+    }
 
-                val scoreInFifths = gradeCalculator.scoreToFifths(CalculationType.MISTAKE, mistakes.toDouble())
-                return SlideshowScoreResult(
-                    score = scoreInFifths,
-                    scaledScore = scaledScore,
-                    correctAnswersCount = calculation.correctAnswersCount,
-                    totalAnswersCount = calculation.totalAnswers
-                )
-            }
-            else -> {
-                val scoreInFifths = gradeCalculator.scoreToFifths(score.type, scaledScore)
-                return SlideshowScoreResult(
-                    score = scoreInFifths,
-                    scaledScore = scaledScore,
-                    correctAnswersCount = calculation.correctAnswersCount,
-                    totalAnswersCount = calculation.totalAnswers
-                )
-            }
-        }
-
+    private fun calculationFormula(
+        score: SlideshowScore,
+        countInteractions: Int
+    ) = if (score.isQuiz) {
+        CalculationType.QUIZ
+    } else if (countInteractions in 2..19) {
+        CalculationType.MISTAKE
+    } else if (countInteractions == 0) {
+        CalculationType.PRESENTATION
+    } else {
+        CalculationType.DEFAULT
     }
 
     private fun calculateMistakes(score: SlideshowScore): Int {
         return score.slideScores.count { !it.isCorrect }
-
     }
 
     private fun calculateScaledScore(userScore: Double, maxScore: Double): Double {
-        return if (maxScore < calculationPrecision || userScore < calculationPrecision) {
-            0.0
+        return if (maxScore < calculationPrecision) {
+            // no possibility to earn (presentations) = best outcome
+            1.0
         } else {
             userScore / maxScore
         }

--- a/src/commonMain/kotlin/com/akelius/university/statistic/core/dto/SlideshowScore.kt
+++ b/src/commonMain/kotlin/com/akelius/university/statistic/core/dto/SlideshowScore.kt
@@ -2,5 +2,5 @@ package com.akelius.university.statistic.core.dto
 
 data class SlideshowScore(
     val slideScores: List<SlideScore>,
-    val type: CalculationType = CalculationType.DEFAULT
+    val isQuiz: Boolean
 )

--- a/src/commonMain/kotlin/com/akelius/university/statistic/core/dto/SlideshowType.kt
+++ b/src/commonMain/kotlin/com/akelius/university/statistic/core/dto/SlideshowType.kt
@@ -4,5 +4,6 @@ enum class CalculationType {
     DEFAULT,
     QUIZ,     // the score is easier on students during QUIZ
     QUIZ_UNLIMITED,     // the score is easier on students during QUIZ
-    MISTAKE
+    MISTAKE,
+    PRESENTATION
 }

--- a/src/commonMain/kotlin/com/akelius/university/statistic/core/grade.calculator/GradeCalculator.kt
+++ b/src/commonMain/kotlin/com/akelius/university/statistic/core/grade.calculator/GradeCalculator.kt
@@ -2,10 +2,11 @@ package com.akelius.university.statistic.core.grade.calculator
 
 import com.akelius.university.statistic.core.dto.CalculationType
 
-class GradeCalculator {
+internal class GradeCalculator {
     private val defaultCalculator = DefaultFifthGradeCalculator()
     private val quizCalculator = QuizFifthGradeCalculator()
     private val mistakeCalculator = MistakeBasedGradeCalculator()
+    private val presentationCalculator = PresentationGradeCalculator()
 
     fun scoreToFifths(calculationType: CalculationType, score: Double): Int {
         return when (calculationType) {
@@ -14,6 +15,9 @@ class GradeCalculator {
             }
             CalculationType.MISTAKE -> {
                 mistakeCalculator.scoreToFifths(score)
+            }
+            CalculationType.PRESENTATION -> {
+                presentationCalculator.scoreToFifths(score)
             }
             else -> {
                 defaultCalculator.scoreToFifths(score)

--- a/src/commonMain/kotlin/com/akelius/university/statistic/core/grade.calculator/PresentationGradeCalculator.kt
+++ b/src/commonMain/kotlin/com/akelius/university/statistic/core/grade.calculator/PresentationGradeCalculator.kt
@@ -1,0 +1,12 @@
+package com.akelius.university.statistic.core.grade.calculator
+
+class PresentationGradeCalculator {
+
+    /**
+     * We always give 5 for:
+     * - presentations
+     * - when weight is 0, and we do branching for storytelling
+     * - when score is not the goal, and weights are 0
+     */
+    fun scoreToFifths(score: Double) = 5
+}

--- a/src/commonTest/kotlin/com/akelius/university/statistic/core/ScoreCalculatorTest.kt
+++ b/src/commonTest/kotlin/com/akelius/university/statistic/core/ScoreCalculatorTest.kt
@@ -14,7 +14,7 @@ class ScoreCalculatorTest {
 
     @Test
     fun singleSlideCalculatesScoreSuccessfully() {
-        val slideshowScore = SlideshowScore(listOf(SlideScore(isCorrect = true, score = 1.0)))
+        val slideshowScore = SlideshowScore(listOf(SlideScore(isCorrect = true, score = 1.0)), false)
 
         val result = calculator.calculate(slideshowScore)
         assertEquals(5, result.score)
@@ -32,7 +32,7 @@ class ScoreCalculatorTest {
             SlideScore(isCorrect = true, score = 1.0, weight = 0.0),
             SlideScore(isCorrect = true, score = 1.0, weight = 0.0),
             SlideScore(isCorrect = true, score = 1.0, weight = 0.0)
-        ))
+        ), false)
 
         val result = calculator.calculate(slideshowScore)
         assertEquals(5, result.score)
@@ -50,7 +50,7 @@ class ScoreCalculatorTest {
             SlideScore(isCorrect = true, score = 1.0, weight = 0.0),
             SlideScore(isCorrect = true, score = 1.0, weight = 0.0),
             SlideScore(isCorrect = true, score = 1.0, weight = 0.0)
-        ))
+        ), false)
 
         val result = calculator.calculate(slideshowScore)
         assertEquals(0, result.score)
@@ -65,7 +65,7 @@ class ScoreCalculatorTest {
             listOf(
                 SlideScore(isCorrect = true, score = 1.0),
                 SlideScore(isCorrect = true)
-            )
+            ), false
         )
 
         val result = calculator.calculate(slideshowScore)
@@ -78,20 +78,75 @@ class ScoreCalculatorTest {
     @Test
     fun mistakeBasedCalculationSuccess() {
         val slideshowScore = SlideshowScore(
-            type = CalculationType.MISTAKE,
             slideScores = listOf(
                 SlideScore(isCorrect = false, score = null),
                 SlideScore(isCorrect = false, score = null),
                 SlideScore(isCorrect = true, score = null),
                 SlideScore(isCorrect = true, score = null),
                 SlideScore(isCorrect = true, score = null)
-            )
+            ), false
         )
 
         val result = calculator.calculate(slideshowScore)
         assertEquals(3, result.score)
         assertEquals(5, result.totalAnswersCount)
         assertEquals(3, result.correctAnswersCount)
+    }
+
+    @Test
+    fun presentationScoreCalculatedCorrectly() {
+        val slideshowScore = SlideshowScore(
+            slideScores = listOf(
+                SlideScore(isCorrect = false, score = 0.0, weight = 0.0),
+                SlideScore(isCorrect = false, score = 0.0, weight = 0.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 0.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 0.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 0.0)
+            ), false
+        )
+
+        val result = calculator.calculate(slideshowScore)
+        assertEquals(5, result.score)
+        assertEquals(0, result.totalAnswersCount)
+        assertEquals(0, result.correctAnswersCount)
+        assertEquals(1.0, result.scaledScore)
+    }
+
+    @Test
+    fun quizScoreCalculatedCorrectly() {
+        val slideshowScore = SlideshowScore(
+            slideScores = listOf(
+                SlideScore(isCorrect = false, score = 0.0, weight = 1.0),
+                SlideScore(isCorrect = false, score = 0.0, weight = 1.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 1.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 1.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 1.0),
+
+                SlideScore(isCorrect = false, score = 0.0, weight = 1.0),
+                SlideScore(isCorrect = false, score = 0.0, weight = 1.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 1.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 1.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 1.0),
+
+                SlideScore(isCorrect = false, score = 0.0, weight = 1.0),
+                SlideScore(isCorrect = false, score = 0.0, weight = 1.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 1.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 1.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 1.0),
+
+                SlideScore(isCorrect = false, score = 0.0, weight = 1.0),
+                SlideScore(isCorrect = false, score = 0.0, weight = 1.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 1.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 1.0),
+                SlideScore(isCorrect = true, score = 1.0, weight = 1.0)
+            ), true
+        )
+
+        val result = calculator.calculate(slideshowScore)
+        assertEquals(1, result.score)
+        assertEquals(20, result.totalAnswersCount)
+        assertEquals(12, result.correctAnswersCount)
+        assertEquals(0.6, result.scaledScore)
     }
 
     @Test
@@ -121,7 +176,7 @@ class ScoreCalculatorTest {
                 SlideScore(isCorrect = false),
                 SlideScore(isCorrect = false, score = 0.79),
                 SlideScore(isCorrect = false)
-            )
+            ), false
         )
 
         val result = calculator.calculate(slideshowScore)
@@ -136,12 +191,12 @@ class ScoreCalculatorTest {
 
     @Test
     fun doesNotFailOnNoSlides() {
-        val result = calculator.calculate(SlideshowScore(emptyList()))
+        val result = calculator.calculate(SlideshowScore(emptyList(), false))
 
-        assertEquals(0, result.score)
+        assertEquals(5, result.score)
         assertEquals(0, result.totalAnswersCount)
         assertEquals(0, result.correctAnswersCount)
-        assertEquals(0.0, result.scaledScore)
+        assertEquals(1.0, result.scaledScore)
     }
 
     @Test
@@ -178,7 +233,7 @@ class ScoreCalculatorTest {
                 SlideScore(isCorrect = true, weight = 0.1),
                 SlideScore(isCorrect = false),
                 SlideScore(isCorrect = true, weight = 0.0)
-            )
+            ), false
         )
 
         val result = calculator.calculate(slideshowScore)
@@ -216,7 +271,7 @@ class ScoreCalculatorTest {
                 SlideScore(isCorrect = true, score = 1.0),
                 SlideScore(isCorrect = true, score = 1.0),
                 SlideScore(isCorrect = true, score = 1.0)
-            )
+            ), false
         )
 
         val result = calculator.calculate(slideshowScore)
@@ -251,7 +306,7 @@ class ScoreCalculatorTest {
                 SlideScore(isCorrect = true, weight = 20.5),
                 SlideScore(isCorrect = false, score = -100.0, maxScore = 100.0, weight = 0.01),
                 SlideScore(isCorrect = true, weight = 20.5)
-            )
+            ), false
         )
 
         val result = calculator.calculate(slideshowScore)
@@ -267,14 +322,14 @@ class ScoreCalculatorTest {
         val slideshowScore = SlideshowScore(
             listOf(
                 SlideScore(isCorrect = false, score = -100.0, maxScore = 100.0, weight = 0.01)
-            )
+            ), false
         )
         val result = calculator.calculate(slideshowScore)
 
         assertEquals(0, result.score)
         assertEquals(1, result.totalAnswersCount)
         assertEquals(0, result.correctAnswersCount)
-        assertTrue(abs(0.0 - result.scaledScore) < calculationPrecision)
+        assertEquals(-1.0, result.scaledScore)
     }
 
     @Test
@@ -315,7 +370,7 @@ class ScoreCalculatorTest {
                 SlideScore(isCorrect = true, score = 80.0, weight = 0.0, maxScore = 100.0),
                 SlideScore(isCorrect = true, score = 80.0, weight = 0.0, maxScore = 100.0),
                 SlideScore(isCorrect = true, score = 80.0, weight = 0.0, maxScore = 100.0)
-            )
+            ), false
         )
 
         val result = calculator.calculate(slideshowScore)

--- a/src/jvmTest/kotlin/com/akelius/university/statistic/core/ScoreCalculatorTestJVM.kt
+++ b/src/jvmTest/kotlin/com/akelius/university/statistic/core/ScoreCalculatorTestJVM.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertEquals
 class ScoreCalculatorTestJVM {
     @Test
     fun success() {
-        val slideshowScore = SlideshowScore(listOf(SlideScore(isCorrect = true, score = 1.0)))
+        val slideshowScore = SlideshowScore(listOf(SlideScore(isCorrect = true, score = 1.0)), false)
 
         val result = ScoreCalculator().calculate(slideshowScore)
         assertEquals(5, result.score)


### PR DESCRIPTION
… on no weights

Changes:
* Make quiz formula always win in priority
* Make presentation separate calculation formula to simplify logic in calculator
* GradeCalculator goes internal as it is too error prone in usage with introduction of mistakes based score
* More tests with real-life scenario

**Action point after merge:** 
As information about slideshow type (Presentation, Test, or Interaction) and amount of slides is available only on write operation: 
* we should start to use fifths calculated at time of writing in both statistic-service and mobile app

